### PR TITLE
build: arxiv 2.2.0 needs at least requests 2.32.0

### DIFF
--- a/nora.yml
+++ b/nora.yml
@@ -47,7 +47,7 @@ dependencies:
     - pytz==2023.3
     - pyyaml==6.0
     - pyzotero==1.5.5
-    - requests==2.28.2
+    - requests==2.32.0
     - rfc3986==1.5.0
     - sgmllib3k==1.0.0
     - six==1.16.0


### PR DESCRIPTION
This PR is referencing Issue #2 which I opened regarding dependency errors for  arxiv 2.2.0 which needs at least requests 2.32.0 compared to the currently set version of 2.28.2.