### PR TITLE
fix: "Internal Server Error" in translation server error handling at correct location

### DIFF
--- a/src/utils/translation_server.py
+++ b/src/utils/translation_server.py
@@ -15,6 +15,9 @@ SERVER_PORT = 1969
 SERVER_IP = f"http://127.0.0.1:{SERVER_PORT}"
 PING_URL = f"{SERVER_IP}/connector/ping"
 
+# `subprocess.check_output` return value for an internal server error
+INTERNAL_SERVER_ERROR = b"Internal Server Error"
+
 # Global server process (singleton pattern)
 _translation_process = None
 
@@ -204,6 +207,11 @@ def translate_from_url(url, timeout=20):
     except subprocess.CalledProcessError:
         print("❌ Failed to contact the translation server. Please check your internet connection or try again.")
         raise RuntimeError("Translation request failed")
+    
+    if out == INTERNAL_SERVER_ERROR:
+        print("❌ The translation server encountered an internal error. Try a different URL.")
+        raise RuntimeError("Translation request failed")
+
     print("✅ Metadata retrieved successfully!")
     return json_to_python(out)
 


### PR DESCRIPTION
This PR adds a new error message to handle cases where the translation server encounters an internal server error. In the previous implementation, the process would still display the message “✅ Metadata retrieved successfully!” even though the metadata retrieval actually failed. The new logic raises a runtime error before that message appears, preventing this misleading feedback.
The updated error message now suggests trying a different URL for the literature reference, which in my case resolves the internal server error. This isn’t strictly a bug fix, but rather an improvement to provide more accurate and helpful feedback to the user.


**Before the fix**
Command:
```
nora url=https://www.mdpi.com/2072-4292/13/12/2331
```
Output:
```
🔄 Starting translation server on port 1969...
⏳ Waiting for server to become ready..
✅ Server is ready!
ℹ️  Retrieving metadata for URL: https://www.mdpi.com/2072-4292/13/12/2331 ...
✅ Metadata retrieved successfully!
Error executing job with overrides: ['url=https://www.mdpi.com/2072-4292/13/12/2331']
Traceback (most recent call last):
  File "/home/valerio/git/nora/nora.py", line 26, in main
    item = ZoteroItem.from_url(cfg.url)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/valerio/git/nora/src/parsers/zotero.py", line 139, in from_url
    return cls(translate_from_url(url, **kwargs))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/valerio/git/nora/src/utils/translation_server.py", line 210, in translate_from_url
    return json_to_python(out)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/valerio/git/nora/src/utils/translation_server.py", line 184, in json_to_python
    raise RuntimeError(data)
RuntimeError: Internal Server Error
```

**After the fix**
Command:
```
nora url=https://www.mdpi.com/2072-4292/13/12/2331
```
Output:
```
🔄 Starting translation server on port 1969...
⏳ Waiting for server to become ready..
✅ Server is ready!
ℹ️  Retrieving metadata for URL: https://www.mdpi.com/2072-4292/13/12/2331 ...
❌ The translation server encountered an internal error. Try a different URL.
Error executing job with overrides: ['url=https://www.mdpi.com/2072-4292/13/12/2331']
Traceback (most recent call last):
  File "/home/valerio/git/nora/nora.py", line 26, in main
    item = ZoteroItem.from_url(cfg.url)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/valerio/git/nora/src/parsers/zotero.py", line 139, in from_url
    return cls(translate_from_url(url, **kwargs))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/valerio/git/nora/src/utils/translation_server.py", line 211, in translate_from_url
    raise RuntimeError("Translation request failed")
RuntimeError: Translation request failed
```

**NoRA command which is successful**
I used a different URL and then it worked:
```
nora url=https://doi.org/10.1111/2041-210X.14061
```
Output:
```
🔄 Starting translation server on port 1969...
⏳ Waiting for server to become ready..
✅ Server is ready!
ℹ️  Retrieving metadata for URL: https://doi.org/10.1111/2041-210X.14061 ...
✅ Metadata retrieved successfully!
⬆️  Uploading 'Machine learning and deep learning—A review for ecologists'...
ℹ️  Paper 'Machine learning and deep learning—A review for ecologists' already exists
✅ Done
```